### PR TITLE
Update GolangCI Lint to v1.55.2 & fix lint violations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,4 @@ workflows:
     jobs:
       - test
       - golangci-lint/lint:
-          tag: v1.52.2
+          tag: v1.55.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,16 @@ linters:
     - maligned         # deprecated and replaced by official fieldalignment.
 
 linters-settings:
+  depguard:
+    rules:
+      # Only allow imports from the stdlib & this module
+      all:
+        list-mode: strict
+        files:
+          - $all
+        allow:
+          - $gostd
+          - github.com/percivalalb/sipuri
   varnamelen:
     max-distance: 17 # default of 5 makes the linter annoying to use.
 

--- a/errors.go
+++ b/errors.go
@@ -97,7 +97,7 @@ func (e EscapeError) Error() string {
 
 // Is makes EscapeError useable with errors.Is.
 func (e EscapeError) Is(input error) bool {
-	_, ok := input.(EscapeError) //nolint:errorlint
+	_, ok := input.(EscapeError)
 
 	return ok
 }


### PR DESCRIPTION
- Updates GolangCI Lint from v1.52.2 to v1.55.2
- Removes unnecessary nolint:errorlint lines (see https://github.com/sylabs/sif/pull/321)
- Adds configuration for new linter depguard (https://github.com/OpenPeeDeeP/depguard), restricting imports to only the stdlib (and this module)