### PR TITLE
Run test job against multiple go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,14 @@ orbs:
 
 jobs:
   test:
+    parameters:
+      version:
+        description: "go version tag"
+        default: "latest"
+        type: string
     working_directory: ~/repo
     docker:
-      - image: cimg/go:1.20.3
+      - image: cimg/go:<<parameters.version>>
     resource_class: small # 1 vCPU, 2GB RAM 
     steps:
       - checkout
@@ -34,6 +39,13 @@ jobs:
 workflows:
   test:
     jobs:
-      - test
       - golangci-lint/lint:
-          tag: v1.55.2
+          tag: 'v1.55.2'
+      - test:
+          matrix:
+            parameters:
+              version:
+                - '1.21'
+                - '1.20'
+                - '1.19'
+                - '1.18'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This module is a pure [Golang](https://go.dev/) implementation to parse URIs with the scheme `sip:` & `sips:`. It tries to adhere to the spec in [RFC-3261 19.1.1](https://www.rfc-editor.org/rfc/rfc3261#section-19.1.1). It is meant to be small and efficent and require no libraries outside the [standard lib](https://pkg.go.dev/std).
 
-Requires go 1.16+ (tested on 1.20)
+Requires go 1.18+
 
 ```console
 go get github.com/percivalalb/sipuri

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/percivalalb/sipuri
 
-go 1.16
+go 1.18


### PR DESCRIPTION
-Run tests on the following buildchains:
  - 1.21.4
  - 1.20.11
  - 1.19.13
  - 1.18.10
- This uncovered that the module utilised [`strings.cut`](https://pkg.go.dev/strings#Cut) which was only added in 1.18. The module was listed as supporting 1.16