### PR TITLE
Update to GolangCI lint v2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
   test:
     jobs:
       - golangci-lint/lint:
-          tag: 'v2.1.6'
+          tag: 'v2.3.0'
       - test:
           matrix:
             parameters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,9 @@ linters:
   default: all
   disable:
     - exhaustruct # is only intended for use in special cases.
+    - noinlineerr # personal preference
     - recvcheck
+    - wsl         # deprecated and replaced by wsl_v5
   settings:
     depguard:
       # Only allow imports from the stdlib & this module

--- a/escape.go
+++ b/escape.go
@@ -334,6 +334,7 @@ type KeyValuePairs map[string][]string
 // encountered.
 func (m *KeyValuePairs) Decode(input, separator string) error {
 	var err error
+
 	*m, err = DecodeURLValues(input, separator)
 
 	return err
@@ -402,6 +403,7 @@ func (EmptyStore) Empty() bool {
 // LazyStore lazily loads a [KeyValuePairs] struct when inspected.
 type LazyStore struct {
 	KeyValuePairs
+
 	input     string
 	separator string
 }


### PR DESCRIPTION
Updates GolangCI lint from `v2.1.6` to `v2.3.0`.

Linters added:
- `embeddedstructfieldcheck`
- `noinlineerr`
- `arangolint`
- `wsl_v5`

It disables the new linter `noinlineerr` as I don't approve of the linter and adjusts whitespace for the v5 of the module.