### PR TITLE
Expose function to access all param/header values

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ import (
 
 func main() {
 	// Parse the URI. Errors on unexpected schemes or malformed URIs
-  	sipURI, err := sipuri.Parse("sip:user:password@host:port;uri-parameters?headers")
+	sipURI, err := sipuri.Parse("sip:user:password@host:port;uri-parameters?headers")
 	if err != nil {
 		panic(err)
 	}
 
-	// Print the consistent components
-   	fmt.Println(sipURI.User()) // user
-   	fmt.Println(sipURI.Password()) // password
-    	fmt.Println(sipURI.Host()) // host:port
-    	fmt.Printf("%v\n", sipURI.Params())  // map[uri-parameters:[]]
-    	fmt.Printf("%v\n", sipURI.Headers()) // map[headers:[]]
+	// Print the constituent components
+	fmt.Println(sipURI.User()) // "user"
+	fmt.Println(sipURI.Password()) // "password"
+	fmt.Println(sipURI.Host()) // "host:port"
+	fmt.Println(sipURI.Params().Get("uri-parameters"))  // ""
+	fmt.Println(sipURI.Headers().GetAll("headers")) // []string{""}
 
 	// Re-construct the URI
-	fmt.Println(sipURI.String()) // sip:user:password@host:port;uri-parameters=?headers=
+	fmt.Println(sipURI.String()) // "sip:user:password@host:port;uri-parameters?headers"
 }
 ```
 

--- a/escape.go
+++ b/escape.go
@@ -317,6 +317,8 @@ func checkValidHexCharacter(hex byte) byte {
 type KeyValueStore interface {
 	// Get returns the first value for the given key. Empty string otherwise.
 	Get(key string) string
+	// GetAll returns all the values for the given key. Nil slice otherwise.
+	GetAll(key string) []string
 	// Encode stringifies the multi-valued map, url encoding keys and values
 	// joining with an ampersand.
 	Encode() string
@@ -354,6 +356,23 @@ func (m KeyValuePairs) Get(key string) string {
 	return vs[0]
 }
 
+// GetAll returns all the values for the given key. Nil slice otherwise.
+func (m KeyValuePairs) GetAll(key string) []string {
+	if m == nil {
+		return nil
+	}
+
+	vs := m[key]
+	if len(vs) == 0 {
+		return nil
+	}
+
+	c := make([]string, len(vs))
+	copy(c, vs)
+
+	return c
+}
+
 // Encode stringifies the multi-valued map, url encoding keys and values
 // joining with an ampersand.
 func (m KeyValuePairs) Encode() string {
@@ -382,6 +401,11 @@ func (EmptyStore) Decode(_, _ string) error {
 // Get returns the first value for the given key. Empty string otherwise.
 func (EmptyStore) Get(_ string) string {
 	return ""
+}
+
+// GetAll returns all the values for the given key. Nil slice otherwise.
+func (EmptyStore) GetAll(_ string) []string {
+	return nil
 }
 
 // Encode stringifies the multi-valued map, url encoding keys and values
@@ -421,6 +445,13 @@ func (s *LazyStore) Get(key string) string {
 	s.load()
 
 	return s.KeyValuePairs.Get(key)
+}
+
+// GetAll returns all the values for the given key. Nil slice otherwise.
+func (s *LazyStore) GetAll(key string) []string {
+	s.load()
+
+	return s.KeyValuePairs.GetAll(key)
 }
 
 // Encode stringifies the multi-valued map, url encoding keys and values

--- a/sipuri_test.go
+++ b/sipuri_test.go
@@ -26,6 +26,14 @@ func TestNew(t *testing.T) {
 	equalF(t, "user", uri.User(), "user mismatch")
 	equalF(t, "password", uri.Password(), "password mismatch")
 	equalF(t, "host:port", uri.Host(), "host mismatch")
+	equalF(t, "", uri.Params().Get("uri-parameters"), "param mismatch")
+	equalF(t, "", uri.Headers().Get("headers"), "header mismatch")
+	equalF(t, []string{""}, uri.Params().GetAll("uri-parameters"), "param mismatch")
+	equalF(t, []string{""}, uri.Headers().GetAll("headers"), "header mismatch")
+	equalF(t, "", uri.Headers().Get("example"), "non-existent header present")
+	equalF(t, []string(nil), uri.Headers().GetAll("example"), "non-existent header present")
+
+	equalF(t, "sip:user:password@host:port;uri-parameters=?headers=", uri.String(), "stringify mismatch")
 }
 
 func ExampleNew() {


### PR DESCRIPTION
Adds `GetAll` function to access all param/header values. Previously you could only fetch the first value for each key. Also update example in README and fixes some typos.