### PR TITLE
Draft: Reduce and clean-up public API footprint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,11 @@ linters:
           allow:
             - $gostd
             - github.com/percivalalb/sipuri
+    revive:
+      rules:
+        package-comments:
+          exclude:
+            - internal/.*
     varnamelen:
       max-distance: 17 # default of 5 makes the linter annoying to use.
   exclusions:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ func main() {
 	uri := sipuri.New(
 		"user",
 		"host:port",
+		// sipuri.Secure(), // Change from sip: to sips:
 		sipuri.WithPassword("password"),
 		sipuri.WithParams(sipuri.Params{
 			"uri-parameters": {""},

--- a/builder.go
+++ b/builder.go
@@ -34,6 +34,7 @@ type Params = map[string][]string
 func WithParams(params Params) uriOption {
 	return func(u *URI) {
 		u.params = internal.KeyValuePairs(params)
+		u.hadParam = true
 	}
 }
 
@@ -53,6 +54,7 @@ type Headers = map[string][]string
 func WithHeaders(headers Headers) uriOption {
 	return func(u *URI) {
 		u.headers = internal.KeyValuePairs(headers)
+		u.hadHeader = true
 	}
 }
 
@@ -63,6 +65,7 @@ func WithHeaders(headers Headers) uriOption {
 func WithPassword(pass string) uriOption {
 	return func(u *URI) {
 		u.pass = pass
+		u.hadPass = true
 	}
 }
 

--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,74 @@
+package sipuri
+
+import "github.com/percivalalb/sipuri/internal"
+
+// New constructs a SIP URI with the given options.
+func New(user, host string, opts ...uriOption) URI {
+	u := URI{
+		user: user,
+		host: host,
+	}
+
+	for _, opt := range opts {
+		opt(&u)
+	}
+
+	return u
+}
+
+type uriOption func(u *URI)
+
+// Params is a throwaway type used by [WithParams] in the [New]
+// builder to hide internal types.
+type Params = map[string][]string
+
+// WithParams allows URI params to be set.
+//
+// It takes a map of string keys paired to a slice of string values.
+// The underlying type is map[string][]string. [net/url.Values] can also
+// be used as a drop in. Example:
+//
+//	sipuri.Params{
+//		"param1": {"value1", "value2"},
+//	}
+func WithParams(params Params) uriOption {
+	return func(u *URI) {
+		u.params = internal.KeyValuePairs(params)
+	}
+}
+
+// Headers is a throwaway type used by [WithHeaders] in the [New]
+// builder to hide internal types.
+type Headers = map[string][]string
+
+// WithHeaders allows URI headers to be set.
+//
+// It takes a map of string keys paired to a slice of string values.
+// The underlying type is map[string][]string. [net/url.Values] can also
+// be used as a drop in. Example:
+//
+//	sipuri.Headers{
+//		"header1": {"value1", "value2"},
+//	}
+func WithHeaders(headers Headers) uriOption {
+	return func(u *URI) {
+		u.headers = internal.KeyValuePairs(headers)
+	}
+}
+
+// WithPassword allows the password portion of the user-info to be set.
+//
+// Use of a password is not advised and is inherently insecure. Use other
+// methods to ensure communication.
+func WithPassword(pass string) uriOption {
+	return func(u *URI) {
+		u.pass = pass
+	}
+}
+
+// Secure upgrades the URI to the SIPS protocol.
+func Secure() uriOption {
+	return func(u *URI) {
+		u.proto = SIPS
+	}
+}

--- a/builder.go
+++ b/builder.go
@@ -25,12 +25,14 @@ type Params = map[string][]string
 // WithParams allows URI params to be set.
 //
 // It takes a map of string keys paired to a slice of string values.
-// The underlying type is map[string][]string. [net/url.Values] can also
-// be used as a drop in. Example:
+// Example:
 //
 //	sipuri.Params{
 //		"param1": {"value1", "value2"},
 //	}
+//
+// [net/url.Values] can also be used as a drop-in given they are an alias for
+// the same underlying type map[string][]string.
 func WithParams(params Params) uriOption {
 	return func(u *URI) {
 		u.params = internal.KeyValuePairs(params)
@@ -45,12 +47,14 @@ type Headers = map[string][]string
 // WithHeaders allows URI headers to be set.
 //
 // It takes a map of string keys paired to a slice of string values.
-// The underlying type is map[string][]string. [net/url.Values] can also
-// be used as a drop in. Example:
+// Example:
 //
 //	sipuri.Headers{
 //		"header1": {"value1", "value2"},
 //	}
+//
+// [net/url.Values] can also be used as a drop-in given they are an alias for
+// the same underlying type map[string][]string.
 func WithHeaders(headers Headers) uriOption {
 	return func(u *URI) {
 		u.headers = internal.KeyValuePairs(headers)
@@ -60,7 +64,7 @@ func WithHeaders(headers Headers) uriOption {
 
 // WithPassword allows the password portion of the user-info to be set.
 //
-// Use of a password is not advised and is inherently insecure. Use other
+// N.b. Use of a password is not advised and is inherently insecure. Use other
 // methods to ensure communication.
 func WithPassword(pass string) uriOption {
 	return func(u *URI) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -74,6 +74,7 @@ func ExampleNew() {
 	sipURI := sipuri.New(
 		"user",
 		"host:port",
+		sipuri.Secure(),
 		sipuri.WithPassword("password"),
 		sipuri.WithParams(sipuri.Params{
 			"uri-parameters": {""},
@@ -83,9 +84,9 @@ func ExampleNew() {
 		}),
 	)
 
-	// Re-construct the URI
+	// Construct the URI:
 	fmt.Println(sipURI.String())
 
 	// Output:
-	// sip:user:password@host:port;uri-parameters=?headers=
+	// sips:user:password@host:port;uri-parameters=?headers=
 }

--- a/errors.go
+++ b/errors.go
@@ -10,14 +10,14 @@ import (
 // MalformCause indicates what part of the URI failed to be parsed.
 type MalformCause uint8
 
-// The possible reasons a URI could be malformed. The cause which relates to the
-// earliest part of the URI is returned.
+// Below are the possible reasons a URI could be malformed. The causes are ordered
+// in the order they are checked.
 const (
 	Unspecified MalformCause = iota
 	InvalidScheme
 	MissingUser
-	MissingHost
 	MalformedUser
+	MissingHost
 	MalformedHost
 	MalformedParams
 	MalformedHeaders
@@ -47,17 +47,17 @@ func (c MalformCause) String() string {
 	}
 }
 
-// MalformedURIError encapsulates an error while processing a sip or sips URI.
-type MalformedURIError struct {
+// MalformedError encapsulates an error while parsing a sip or sips URI.
+type MalformedError struct {
 	Cause MalformCause
 	Err   error
 }
 
 // Error returns a string representation of the error.
-func (err MalformedURIError) Error() string {
+func (err MalformedError) Error() string {
 	var builder strings.Builder
 
-	builder.WriteString("sip: malformed uri")
+	builder.WriteString("sip: malformed URI")
 
 	if err.Cause != Unspecified {
 		builder.WriteString(": " + err.Cause.String())
@@ -70,12 +70,12 @@ func (err MalformedURIError) Error() string {
 	return builder.String()
 }
 
-// Is returns if the given error is also a [MalformedURIError] struct of the same cause.
+// Is returns if the given error is also a [MalformedError] struct of the same cause.
 //
 // If the input does not have a cause specified then it matches any
-// [MalformedURIError] struct.
-func (err MalformedURIError) Is(input error) bool {
-	var inputMal MalformedURIError
+// [MalformedError] struct.
+func (err MalformedError) Is(input error) bool {
+	var inputMal MalformedError
 	if errors.As(input, &inputMal) {
 		return inputMal.Cause == Unspecified || inputMal.Cause == err.Cause
 	}
@@ -84,9 +84,10 @@ func (err MalformedURIError) Is(input error) bool {
 }
 
 // Unwrap returns the underlying error.
-func (err MalformedURIError) Unwrap() error {
+func (err MalformedError) Unwrap() error {
 	return err.Err
 }
 
-// EscapeError is returned when a byte-pair has been incorrectly URL encoded.
-type EscapeError = internal.EscapeError
+// EscapeError is returned when a '%' character in a URL string is not
+// followed by a valid hexadecimal byte.
+type EscapeError = internal.URIEscapeError

--- a/errors.go
+++ b/errors.go
@@ -7,9 +7,6 @@ import (
 	"github.com/percivalalb/sipuri/internal"
 )
 
-// ErrInvalidScheme is returned when a string that does not start sip: or sips: is given.
-var ErrInvalidScheme = errors.New("sip: scheme invalid")
-
 // MalformCause indicates what part of the URI failed to be parsed.
 type MalformCause uint8
 
@@ -17,6 +14,7 @@ type MalformCause uint8
 // earliest part of the URI is returned.
 const (
 	Unspecified MalformCause = iota
+	InvalidScheme
 	MissingUser
 	MissingHost
 	MalformedUser
@@ -30,6 +28,8 @@ func (c MalformCause) String() string {
 	switch c {
 	case Unspecified:
 		return "unspecified"
+	case InvalidScheme:
+		return "invalid scheme"
 	case MissingUser:
 		return "missing user"
 	case MissingHost:

--- a/errors.go
+++ b/errors.go
@@ -2,8 +2,9 @@ package sipuri
 
 import (
 	"errors"
-	"strconv"
 	"strings"
+
+	"github.com/percivalalb/sipuri/internal"
 )
 
 // ErrInvalidScheme is returned when a string that does not start sip: or sips: is given.
@@ -88,16 +89,4 @@ func (err MalformedURIError) Unwrap() error {
 }
 
 // EscapeError is returned when a byte-pair has been incorrectly URL encoded.
-type EscapeError string
-
-// Error returns the string representation of the error.
-func (e EscapeError) Error() string {
-	return "sip: invalid URL escape " + strconv.Quote(string(e))
-}
-
-// Is allows [EscapeError] to be compared by [errors.Is].
-func (e EscapeError) Is(input error) bool {
-	_, ok := input.(EscapeError)
-
-	return ok
-}
+type EscapeError = internal.EscapeError

--- a/errors_test.go
+++ b/errors_test.go
@@ -42,7 +42,7 @@ func TestMalformCause(t *testing.T) {
 	t.Parallel()
 
 	tests := []sipuri.MalformCause{
-		sipuri.Unspecified, sipuri.MissingUser, sipuri.MissingHost,
+		sipuri.Unspecified, sipuri.InvalidScheme, sipuri.MissingUser, sipuri.MissingHost,
 		sipuri.MalformedUser, sipuri.MalformedParams, sipuri.MalformedHeaders,
 	}
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/percivalalb/sipuri"
 )
 
-func TestMalformedURIError(t *testing.T) {
+func TestMalformedError(t *testing.T) {
 	t.Parallel()
 
-	unspecifiedErr := sipuri.MalformedURIError{} // zero value
-	missingUserErr := sipuri.MalformedURIError{Cause: sipuri.MissingUser}
-	missingHostErr := sipuri.MalformedURIError{Cause: sipuri.MissingHost}
+	unspecifiedErr := sipuri.MalformedError{} // zero value
+	missingUserErr := sipuri.MalformedError{Cause: sipuri.MissingUser}
+	missingHostErr := sipuri.MalformedError{Cause: sipuri.MissingHost}
 
 	if !errors.Is(missingUserErr, unspecifiedErr) {
 		t.Fatalf("unspecified cause matches any malform error")
@@ -26,16 +26,16 @@ func TestMalformedURIError(t *testing.T) {
 		t.Fatalf("specific cause matches does not match another cause")
 	}
 
-	var malformError sipuri.MalformedURIError
+	var malformError sipuri.MalformedError
 	if !errors.As(missingUserErr, &malformError) {
 		t.Fatalf("unspecified cause malform error")
 	}
 
 	equalF(t, missingUserErr.Cause, malformError.Cause, "error.As for same cause")
 
-	equalF(t, "sip: malformed uri", unspecifiedErr.Error(), "unspecified cause string representation")
-	equalF(t, "sip: malformed uri: missing user", missingUserErr.Error(), "missing user cause string representation")
-	equalF(t, "sip: malformed uri: missing host", missingHostErr.Error(), "missing host cause string representation")
+	equalF(t, "sip: malformed URI", unspecifiedErr.Error(), "unspecified cause string representation")
+	equalF(t, "sip: malformed URI: missing user", missingUserErr.Error(), "missing user cause string representation")
+	equalF(t, "sip: malformed URI: missing host", missingHostErr.Error(), "missing host cause string representation")
 }
 
 func TestMalformCause(t *testing.T) {

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,18 @@
+package internal
+
+import "strconv"
+
+// EscapeError is returned when a byte-pair has been incorrectly URL encoded.
+type EscapeError string
+
+// Error returns the string representation of the error.
+func (e EscapeError) Error() string {
+	return "sip: invalid URL escape " + strconv.Quote(string(e))
+}
+
+// Is allows [EscapeError] to be compared by [errors.Is].
+func (e EscapeError) Is(input error) bool {
+	_, ok := input.(EscapeError)
+
+	return ok
+}

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -2,17 +2,18 @@ package internal
 
 import "strconv"
 
-// EscapeError is returned when a byte-pair has been incorrectly URL encoded.
-type EscapeError string
+// EscapeError is returned when a '%' character in a URL string is not
+// followed by a valid hexadecimal byte.
+type URIEscapeError string
 
 // Error returns the string representation of the error.
-func (e EscapeError) Error() string {
+func (e URIEscapeError) Error() string {
 	return "sip: invalid URL escape " + strconv.Quote(string(e))
 }
 
 // Is allows [EscapeError] to be compared by [errors.Is].
-func (e EscapeError) Is(input error) bool {
-	_, ok := input.(EscapeError)
+func (e URIEscapeError) Is(input error) bool {
+	_, ok := input.(URIEscapeError)
 
 	return ok
 }

--- a/internal/escape.go
+++ b/internal/escape.go
@@ -231,7 +231,7 @@ func Unescape(input string) (string, error) {
 
 			// not enought characters for
 			if i >= len(input) {
-				return "", EscapeError(input[i-2:])
+				return "", URIEscapeError(input[i-2:])
 			}
 		}
 	}
@@ -263,9 +263,9 @@ func UnescapeErrorChecker(input string) error {
 	case l == 0:
 		return nil
 	case input[l-1] == '%':
-		return EscapeError("%")
+		return URIEscapeError("%")
 	case input[l-2] == '%':
-		return EscapeError(input[l-2:])
+		return URIEscapeError(input[l-2:])
 	}
 
 	for pos := 0; pos < l; pos++ {
@@ -274,7 +274,7 @@ func UnescapeErrorChecker(input string) error {
 			lByte := checkValidHexCharacter(input[pos+2])
 
 			if (gByte|lByte)&hexCharErrorBit != 0 {
-				return EscapeError(input[pos : pos+3])
+				return URIEscapeError(input[pos : pos+3])
 			}
 
 			pos += 2
@@ -295,7 +295,7 @@ func unescapeInto(input string, offset int, target []byte) (int, error) {
 			lByte := checkValidHexCharacter(input[pos+2])
 
 			if (gByte|lByte)&hexCharErrorBit != 0 {
-				return 0, EscapeError(input[pos : pos+3])
+				return 0, URIEscapeError(input[pos : pos+3])
 			}
 
 			target[offset] = gByte<<4 + lByte //nolint:mnd

--- a/internal/escape.go
+++ b/internal/escape.go
@@ -1,9 +1,8 @@
-package sipuri
+package internal
 
 import (
 	"sort"
 	"strings"
-	"sync"
 )
 
 // This file is an alternative to the stdlib module url with some
@@ -15,9 +14,9 @@ import (
 type encoding int
 
 const (
-	encodeHost encoding = 1 + iota
-	encodeUserPassword
-	encodeQueryComponent
+	EncodeHost encoding = 1 + iota
+	EncodeUserPassword
+	EncodeQueryComponent
 )
 
 // shouldEscape returns if the given character should be escaped in the
@@ -33,7 +32,7 @@ func (mode encoding) shouldEscape(char byte) bool {
 		return false
 	}
 
-	if mode == encodeHost {
+	if mode == EncodeHost {
 		// §3.2.2 Host allows:
 		switch char {
 		case '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', ':', '[', ']', '<', '>', '"':
@@ -49,13 +48,13 @@ func (mode encoding) shouldEscape(char byte) bool {
 		// Different sections of the URI allow a few of
 		// the reserved characters to appear unescaped.
 		switch mode { //nolint:exhaustive
-		case encodeUserPassword: // §3.2.1
+		case EncodeUserPassword: // §3.2.1
 			// The RFC allows ';', ':', '&', '=', '+', '$', and ',' in
 			// userinfo, so we must escape only '@', '/', and '?'.
 			// The parsing of userinfo treats ':' as special so we must escape
 			// that too.
 			return char == '@' || char == '/' || char == '?' || char == ':'
-		case encodeQueryComponent: // §3.4
+		case EncodeQueryComponent: // §3.4
 			// The RFC reserves (so we must escape) everything.
 			return true
 		}
@@ -68,7 +67,7 @@ func (mode encoding) shouldEscape(char byte) bool {
 // escape encodes characters based on the context of the string
 //
 // Based on url.escape but tweaked and optimised.
-func escape(input string, mode encoding) string {
+func Escape(input string, mode encoding) string {
 	var hexCount int
 
 	for i := 0; i < len(input); i++ {
@@ -147,7 +146,7 @@ func EncodeURLValues(input map[string][]string) string {
 		keys = append(keys, key)
 
 		for i := 0; i < len(key); i++ {
-			if encodeQueryComponent.shouldEscape(key[i]) {
+			if EncodeQueryComponent.shouldEscape(key[i]) {
 				hexCount += vsCount
 			}
 		}
@@ -157,7 +156,7 @@ func EncodeURLValues(input map[string][]string) string {
 
 		for _, val := range vals {
 			for i := 0; i < len(val); i++ {
-				if encodeQueryComponent.shouldEscape(val[i]) {
+				if EncodeQueryComponent.shouldEscape(val[i]) {
 					hexCount++
 				}
 			}
@@ -203,7 +202,7 @@ const upperhex = "0123456789ABCDEF"
 func escapeInto(input string, offset int, target []byte) int {
 	for pos := 0; pos < len(input); pos++ {
 		switch c := input[pos]; {
-		case encodeQueryComponent.shouldEscape(c):
+		case EncodeQueryComponent.shouldEscape(c):
 			target[offset] = '%'
 			target[offset+1] = upperhex[c>>4]
 			target[offset+2] = upperhex[c&15]
@@ -255,7 +254,7 @@ func Unescape(input string) (string, error) {
 
 // UnescapeErrorChecker scans the input checking for malformed encoded entities.
 //
-// It is a stripped down version of Unescape without actually extracting the parts
+// It is a stripped down version of [Unescape] without actually extracting the parts
 // or decoding the string it returns an error if and only if the aforementioned does.
 func UnescapeErrorChecker(input string) error {
 	l := len(input)
@@ -326,212 +325,4 @@ func checkValidHexCharacter(hex byte) byte {
 	}
 
 	return hexCharErrorBit
-}
-
-// KeyValueStore provides access to a multi-valued map.
-type KeyValueStore interface {
-	// Get returns the first value for the given key. Empty string otherwise.
-	Get(key string) string
-	// GetAll returns all the values for the given key. Nil slice otherwise.
-	GetAll(key string) []string
-	// Keys returns all the keys in no particular order. Nil slice if there are none.
-	Keys() []string
-	// Encode stringifies the multi-valued map, url encoding keys and values
-	// joining with an ampersand.
-	Encode() string
-	// Len returns the number of distinct keys.
-	Len() int
-	// Empty returns if the store contains no keys.
-	Empty() bool
-}
-
-// KeyValuePairs stores key to values similar to that of [url.Values]
-// and implements [KeyValueStore].
-type KeyValuePairs map[string][]string
-
-// Decode populates the Store with the given data, returing any encoding errors
-// encountered.
-func (m *KeyValuePairs) Decode(input, separator string) error {
-	var err error
-
-	*m, err = DecodeURLValues(input, separator)
-
-	return err
-}
-
-// Get returns the first value for the given key. Empty string otherwise.
-func (m KeyValuePairs) Get(key string) string {
-	if m == nil {
-		return ""
-	}
-
-	vs := m[key]
-	if len(vs) == 0 {
-		return ""
-	}
-
-	return vs[0]
-}
-
-// GetAll returns all the values for the given key. Nil slice otherwise.
-func (m KeyValuePairs) GetAll(key string) []string {
-	if m == nil {
-		return nil
-	}
-
-	vs := m[key]
-	if len(vs) == 0 {
-		return nil
-	}
-
-	c := make([]string, len(vs))
-	copy(c, vs)
-
-	return c
-}
-
-// Keys returns all the keys in no particular order. Nil slice if there are none.
-func (m KeyValuePairs) Keys() []string {
-	l := len(m)
-	if l == 0 {
-		return nil
-	}
-
-	keys := make([]string, 0, l)
-
-	for k := range m {
-		keys = append(keys, k)
-	}
-
-	return keys
-}
-
-// Encode stringifies the multi-valued map, url encoding keys and values
-// joining with an ampersand.
-func (m KeyValuePairs) Encode() string {
-	return EncodeURLValues(m)
-}
-
-// Len returns the number of distinct keys.
-func (m KeyValuePairs) Len() int {
-	return len(m)
-}
-
-// Empty returns if the store contains no keys.
-func (m KeyValuePairs) Empty() bool {
-	return len(m) == 0
-}
-
-// EmptyStore represents an always empty multi-valued map.
-type EmptyStore struct{}
-
-// Decode populates the Store with the given data, returing any encoding errors
-// encountered.
-func (EmptyStore) Decode(_, _ string) error {
-	return nil
-}
-
-// Get returns the first value for the given key. Empty string otherwise.
-func (EmptyStore) Get(_ string) string {
-	return ""
-}
-
-// GetAll returns all the values for the given key. Nil slice otherwise.
-func (EmptyStore) GetAll(_ string) []string {
-	return nil
-}
-
-// Keys returns all the keys in no particular order. Nil slice if there are none.
-func (EmptyStore) Keys() []string {
-	return nil
-}
-
-// Encode stringifies the multi-valued map, url encoding keys and values
-// joining with an ampersand.
-func (EmptyStore) Encode() string {
-	return ""
-}
-
-// Len returns the number of distinct keys.
-func (EmptyStore) Len() int {
-	return 0
-}
-
-// Empty returns if the store contains no keys.
-func (EmptyStore) Empty() bool {
-	return true
-}
-
-// LazyStore lazily loads a [KeyValuePairs] struct when inspected.
-type LazyStore struct {
-	KeyValuePairs
-
-	once      sync.Once // protects the above
-	input     string
-	separator string
-}
-
-// Decode populates the Store with the given data. Always scans the input for encoding errors.
-func (s *LazyStore) Decode(input, separator string) error {
-	s.input = input
-	s.separator = separator
-
-	return UnescapeErrorChecker(input)
-}
-
-// Get returns the first value for the given key. Empty string otherwise.
-func (s *LazyStore) Get(key string) string {
-	s.load()
-
-	return s.KeyValuePairs.Get(key)
-}
-
-// GetAll returns all the values for the given key. Nil slice otherwise.
-func (s *LazyStore) GetAll(key string) []string {
-	s.load()
-
-	return s.KeyValuePairs.GetAll(key)
-}
-
-// Keys returns all the keys in no particular order. Nil slice if there are none.
-func (s *LazyStore) Keys() []string {
-	s.load()
-
-	return s.KeyValuePairs.Keys()
-}
-
-// Encode stringifies the multi-valued map, url encoding keys and values
-// joining with an ampersand.
-func (s *LazyStore) Encode() string {
-	s.load()
-
-	return s.KeyValuePairs.Encode()
-}
-
-// Len returns the number of distinct keys.
-func (s *LazyStore) Len() int {
-	s.load()
-
-	return s.KeyValuePairs.Len()
-}
-
-// Empty returns if the store contains no keys.
-func (s *LazyStore) Empty() bool {
-	if s.KeyValuePairs != nil {
-		return s.KeyValuePairs.Empty()
-	}
-
-	return s.input == ""
-}
-
-func (s *LazyStore) load() {
-	s.once.Do(func() {
-		// Any possible errors have already been checked in the Decode
-		// call to [UnescapeErrorChecker].
-		//nolint:errcheck,gosec
-		(&s.KeyValuePairs).Decode(s.input, s.separator)
-
-		s.input = ""
-		s.separator = ""
-	})
 }

--- a/internal/escape_test.go
+++ b/internal/escape_test.go
@@ -40,6 +40,13 @@ func TestURLEncodeURLValues(t *testing.T) {
 			"",
 			"zero-length key-value pair",
 		},
+		{
+			internal.KeyValuePairs{
+				"a%a": []string{"%bb"},
+			},
+			"a%25a=%25bb",
+			"encoding percentage symbol",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/escape_test.go
+++ b/internal/escape_test.go
@@ -1,12 +1,13 @@
-package sipuri_test
+package internal_test
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
-	"sort"
+	"reflect"
 	"testing"
 
-	"github.com/percivalalb/sipuri"
+	"github.com/percivalalb/sipuri/internal"
 )
 
 func TestURLEncodeURLValues(t *testing.T) {
@@ -25,7 +26,7 @@ func TestURLEncodeURLValues(t *testing.T) {
 			"typical example",
 		},
 		{
-			sipuri.KeyValuePairs{
+			internal.KeyValuePairs{
 				"shapes":  []string{"square", "circle"},
 				"colours": []string{"red", "blue", "green"},
 			},
@@ -33,7 +34,7 @@ func TestURLEncodeURLValues(t *testing.T) {
 			"zero-length key-value pair",
 		},
 		{
-			sipuri.KeyValuePairs{
+			internal.KeyValuePairs{
 				"users": nil,
 			},
 			"",
@@ -42,7 +43,7 @@ func TestURLEncodeURLValues(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := sipuri.EncodeURLValues(test.input)
+		got := internal.EncodeURLValues(test.input)
 
 		equalF(t, test.expect, got, "%s: encodeURLValues(%v) = %q want %q",
 			test.msg, test.input, got, testQueryString)
@@ -54,35 +55,35 @@ func TestURLDecodeURLValues(t *testing.T) {
 
 	type test struct {
 		input  string
-		expect sipuri.KeyValuePairs
+		expect internal.KeyValuePairs
 		msg    string
 	}
 
 	tests := []test{
 		{
 			"transport=TCP",
-			sipuri.KeyValuePairs{
+			internal.KeyValuePairs{
 				"transport": {"TCP"},
 			},
 			"single key-value pair",
 		},
 		{
 			"transport=",
-			sipuri.KeyValuePairs{
+			internal.KeyValuePairs{
 				"transport": {""},
 			},
 			"singleton",
 		},
 		{
 			"transport",
-			sipuri.KeyValuePairs{
+			internal.KeyValuePairs{
 				"transport": {""},
 			},
 			"singleton",
 		},
 		{
 			"transport=TCP;user=percivalalb;group=polarbear",
-			sipuri.KeyValuePairs{
+			internal.KeyValuePairs{
 				"transport": {"TCP"},
 				"user":      {"percivalalb"},
 				"group":     {"polarbear"},
@@ -92,9 +93,9 @@ func TestURLDecodeURLValues(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result, err := sipuri.DecodeURLValues(test.input, ";")
+		result, err := internal.DecodeURLValues(test.input, ";")
 
-		equalF(t, err, sipuri.UnescapeErrorChecker(test.input), "checker matches")
+		equalF(t, err, internal.UnescapeErrorChecker(test.input), "checker matches")
 
 		if err != nil {
 			t.Fatalf("err %v", err)
@@ -108,7 +109,7 @@ func TestUnescape(t *testing.T) {
 	t.Parallel()
 
 	expect := "cat=meow&dog=bark!&dog=woof@&mouse=ee  eeΔ&parrot=(hellow)"
-	got, _ := sipuri.Unescape(testQueryString)
+	got, _ := internal.Unescape(testQueryString)
 
 	equalF(t, expect, got, "Unescape(%q) = %q want %q", testQueryString, got, expect)
 }
@@ -116,126 +117,29 @@ func TestUnescape(t *testing.T) {
 func TestUnescapeError(t *testing.T) {
 	t.Parallel()
 
-	_, err := sipuri.Unescape("bark%2y")
+	_, err := internal.Unescape("bark%2y")
 
-	if !errors.Is(err, sipuri.EscapeError("%2y")) {
+	if !errors.Is(err, internal.EscapeError("%2y")) {
 		t.Fatalf("err %v", err)
 	}
 
-	equalF(t, err, sipuri.UnescapeErrorChecker("bark%2y"), "checker matches")
+	equalF(t, err, internal.UnescapeErrorChecker("bark%2y"), "checker matches")
 
-	_, err = sipuri.Unescape("bark%2")
+	_, err = internal.Unescape("bark%2")
 
-	if !errors.Is(err, sipuri.EscapeError("%2")) {
+	if !errors.Is(err, internal.EscapeError("%2")) {
 		t.Fatalf("err %v", err)
 	}
 
-	equalF(t, err, sipuri.UnescapeErrorChecker("bark%2"), "checker matches")
+	equalF(t, err, internal.UnescapeErrorChecker("bark%2"), "checker matches")
 
-	_, err = sipuri.Unescape("bark%")
+	_, err = internal.Unescape("bark%")
 
-	if !errors.Is(err, sipuri.EscapeError("%")) {
+	if !errors.Is(err, internal.EscapeError("%")) {
 		t.Fatalf("err %v", err)
 	}
 
-	equalF(t, err, sipuri.UnescapeErrorChecker("bark%"), "checker matches")
-}
-
-func TestKeyValueStore(t *testing.T) {
-	t.Parallel()
-
-	type test struct {
-		input        sipuri.KeyValueStore
-		expectValues map[string][]string
-		expectKeys   []string
-		msg          string
-	}
-
-	tests := []test{
-		{
-			sipuri.KeyValuePairs{},
-			map[string][]string{
-				"unknown": nil,
-			},
-			nil,
-			"empty key/value pairs",
-		},
-		{
-			sipuri.KeyValuePairs{
-				"key1": {""},
-			},
-			map[string][]string{
-				"key1": {""},
-			},
-			[]string{"key1"},
-			"key/value pairs single key",
-		},
-		{
-			sipuri.KeyValuePairs{
-				"animals":   {"cat", "dog", "parrot"},
-				"health":    {"good", "good", "good"},
-				"locations": {"england"},
-			},
-			map[string][]string{
-				"animals":   {"cat", "dog", "parrot"},
-				"health":    {"good", "good", "good"},
-				"locations": {"england"},
-			},
-			[]string{"animals", "health", "locations"},
-			"many key/value pairs",
-		},
-		{
-			sipuri.EmptyStore{},
-			map[string][]string{
-				"unknown": nil,
-			},
-			nil,
-			"empty store",
-		},
-		{
-			createLazyStore(t, "key1=value1&key2=value2&key3=value2&key1=value1", "&"),
-			map[string][]string{
-				"key1":    {"value1", "value1"},
-				"key2":    {"value2"},
-				"key3":    {"value2"},
-				"unknown": nil,
-			},
-			[]string{"key1", "key2", "key3"},
-			"lazy store",
-		},
-	}
-
-	for _, test := range tests {
-		for k, v := range test.expectValues {
-			var firstV string
-			if len(v) > 0 {
-				firstV = v[0]
-			}
-
-			equalF(t, firstV, test.input.Get(k), "%s: first value mismatch", test.msg)
-			equalF(t, v, test.input.GetAll(k), "%s: values mismatch", test.msg)
-		}
-
-		// Sorts as keys are returned in an arbitrary order.
-		keys := test.input.Keys()
-		sort.Strings(keys)
-
-		equalF(t, test.expectKeys, keys, "%s: keys mismatch", test.msg)
-
-		equalF(t, len(test.expectKeys), test.input.Len(), "%s: len mismatch", test.msg)
-	}
-}
-
-func createLazyStore(t *testing.T, input, separator string) *sipuri.LazyStore {
-	t.Helper()
-
-	s := &sipuri.LazyStore{}
-
-	if err := s.Decode(input, separator); err != nil {
-		t.Fatalf("err %v", err)
-	}
-
-	return s
+	equalF(t, err, internal.UnescapeErrorChecker("bark%"), "checker matches")
 }
 
 // func FuzzReverse(f *testing.F) {
@@ -272,7 +176,7 @@ func BenchmarkEncodeURLValues(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = sipuri.EncodeURLValues(query)
+		_ = internal.EncodeURLValues(query)
 	}
 }
 
@@ -288,7 +192,7 @@ func BenchmarkUnescape(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = sipuri.Unescape(testQueryString)
+		_, _ = internal.Unescape(testQueryString)
 	}
 }
 
@@ -303,4 +207,12 @@ func getTestURLValues() url.Values {
 	query.Add("mouse", "ee  eeΔ")
 
 	return query
+}
+
+func equalF(t *testing.T, e interface{}, g interface{}, m string, a ...interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(e, g) {
+		t.Fatalf(`%q != %q, %s`, e, g, fmt.Sprintf(m, a...))
+	}
 }

--- a/internal/escape_test.go
+++ b/internal/escape_test.go
@@ -119,7 +119,7 @@ func TestUnescapeError(t *testing.T) {
 
 	_, err := internal.Unescape("bark%2y")
 
-	if !errors.Is(err, internal.EscapeError("%2y")) {
+	if !errors.Is(err, internal.URIEscapeError("%2y")) {
 		t.Fatalf("err %v", err)
 	}
 
@@ -127,7 +127,7 @@ func TestUnescapeError(t *testing.T) {
 
 	_, err = internal.Unescape("bark%2")
 
-	if !errors.Is(err, internal.EscapeError("%2")) {
+	if !errors.Is(err, internal.URIEscapeError("%2")) {
 		t.Fatalf("err %v", err)
 	}
 
@@ -135,7 +135,7 @@ func TestUnescapeError(t *testing.T) {
 
 	_, err = internal.Unescape("bark%")
 
-	if !errors.Is(err, internal.EscapeError("%")) {
+	if !errors.Is(err, internal.URIEscapeError("%")) {
 		t.Fatalf("err %v", err)
 	}
 

--- a/internal/store.go
+++ b/internal/store.go
@@ -15,8 +15,6 @@ type KeyValueStore interface {
 	Encode() string
 	// Len returns the number of distinct keys.
 	Len() int
-	// Empty returns if the store contains no keys.
-	Empty() bool
 }
 
 // KeyValuePairs stores key to values similar to that of [url.Values]
@@ -91,11 +89,6 @@ func (m KeyValuePairs) Len() int {
 	return len(m)
 }
 
-// Empty returns if the store contains no keys.
-func (m KeyValuePairs) Empty() bool {
-	return len(m) == 0
-}
-
 // EmptyStore represents an always empty multi-valued map.
 type EmptyStore struct{}
 
@@ -129,11 +122,6 @@ func (EmptyStore) Encode() string {
 // Len returns the number of distinct keys.
 func (EmptyStore) Len() int {
 	return 0
-}
-
-// Empty returns if the store contains no keys.
-func (EmptyStore) Empty() bool {
-	return true
 }
 
 // LazyStore lazily loads a [KeyValuePairs] struct when inspected.
@@ -187,15 +175,6 @@ func (s *LazyStore) Len() int {
 	s.load()
 
 	return s.KeyValuePairs.Len()
-}
-
-// Empty returns if the store contains no keys.
-func (s *LazyStore) Empty() bool {
-	if s.KeyValuePairs != nil {
-		return s.KeyValuePairs.Empty()
-	}
-
-	return s.input == ""
 }
 
 func (s *LazyStore) load() {

--- a/internal/store.go
+++ b/internal/store.go
@@ -1,0 +1,211 @@
+package internal
+
+import "sync"
+
+// KeyValueStore provides access to a multi-valued map.
+type KeyValueStore interface {
+	// Get returns the first value for the given key. Empty string otherwise.
+	Get(key string) string
+	// GetAll returns all the values for the given key. Nil slice otherwise.
+	GetAll(key string) []string
+	// Keys returns all the keys in no particular order. Nil slice if there are none.
+	Keys() []string
+	// Encode stringifies the multi-valued map, url encoding keys and values
+	// joining with an ampersand.
+	Encode() string
+	// Len returns the number of distinct keys.
+	Len() int
+	// Empty returns if the store contains no keys.
+	Empty() bool
+}
+
+// KeyValuePairs stores key to values similar to that of [url.Values]
+// and implements [KeyValueStore].
+type KeyValuePairs map[string][]string
+
+// Decode populates the Store with the given data, returing any encoding errors
+// encountered.
+func (m *KeyValuePairs) Decode(input, separator string) error {
+	var err error
+
+	*m, err = DecodeURLValues(input, separator)
+
+	return err
+}
+
+// Get returns the first value for the given key. Empty string otherwise.
+func (m KeyValuePairs) Get(key string) string {
+	if m == nil {
+		return ""
+	}
+
+	vs := m[key]
+	if len(vs) == 0 {
+		return ""
+	}
+
+	return vs[0]
+}
+
+// GetAll returns all the values for the given key. Nil slice otherwise.
+func (m KeyValuePairs) GetAll(key string) []string {
+	if m == nil {
+		return nil
+	}
+
+	vs := m[key]
+	if len(vs) == 0 {
+		return nil
+	}
+
+	c := make([]string, len(vs))
+	copy(c, vs)
+
+	return c
+}
+
+// Keys returns all the keys in no particular order. Nil slice if there are none.
+func (m KeyValuePairs) Keys() []string {
+	l := len(m)
+	if l == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, l)
+
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+// Encode stringifies the multi-valued map, url encoding keys and values
+// joining with an ampersand.
+func (m KeyValuePairs) Encode() string {
+	return EncodeURLValues(m)
+}
+
+// Len returns the number of distinct keys.
+func (m KeyValuePairs) Len() int {
+	return len(m)
+}
+
+// Empty returns if the store contains no keys.
+func (m KeyValuePairs) Empty() bool {
+	return len(m) == 0
+}
+
+// EmptyStore represents an always empty multi-valued map.
+type EmptyStore struct{}
+
+// Decode populates the Store with the given data, returing any encoding errors
+// encountered.
+func (EmptyStore) Decode(_, _ string) error {
+	return nil
+}
+
+// Get returns the first value for the given key. Empty string otherwise.
+func (EmptyStore) Get(_ string) string {
+	return ""
+}
+
+// GetAll returns all the values for the given key. Nil slice otherwise.
+func (EmptyStore) GetAll(_ string) []string {
+	return nil
+}
+
+// Keys returns all the keys in no particular order. Nil slice if there are none.
+func (EmptyStore) Keys() []string {
+	return nil
+}
+
+// Encode stringifies the multi-valued map, url encoding keys and values
+// joining with an ampersand.
+func (EmptyStore) Encode() string {
+	return ""
+}
+
+// Len returns the number of distinct keys.
+func (EmptyStore) Len() int {
+	return 0
+}
+
+// Empty returns if the store contains no keys.
+func (EmptyStore) Empty() bool {
+	return true
+}
+
+// LazyStore lazily loads a [KeyValuePairs] struct when inspected.
+type LazyStore struct {
+	KeyValuePairs
+
+	once      sync.Once // protects the above
+	input     string
+	separator string
+}
+
+// Decode populates the Store with the given data. Always scans the input for encoding errors.
+func (s *LazyStore) Decode(input, separator string) error {
+	s.input = input
+	s.separator = separator
+
+	return UnescapeErrorChecker(input)
+}
+
+// Get returns the first value for the given key. Empty string otherwise.
+func (s *LazyStore) Get(key string) string {
+	s.load()
+
+	return s.KeyValuePairs.Get(key)
+}
+
+// GetAll returns all the values for the given key. Nil slice otherwise.
+func (s *LazyStore) GetAll(key string) []string {
+	s.load()
+
+	return s.KeyValuePairs.GetAll(key)
+}
+
+// Keys returns all the keys in no particular order. Nil slice if there are none.
+func (s *LazyStore) Keys() []string {
+	s.load()
+
+	return s.KeyValuePairs.Keys()
+}
+
+// Encode stringifies the multi-valued map, url encoding keys and values
+// joining with an ampersand.
+func (s *LazyStore) Encode() string {
+	s.load()
+
+	return s.KeyValuePairs.Encode()
+}
+
+// Len returns the number of distinct keys.
+func (s *LazyStore) Len() int {
+	s.load()
+
+	return s.KeyValuePairs.Len()
+}
+
+// Empty returns if the store contains no keys.
+func (s *LazyStore) Empty() bool {
+	if s.KeyValuePairs != nil {
+		return s.KeyValuePairs.Empty()
+	}
+
+	return s.input == ""
+}
+
+func (s *LazyStore) load() {
+	s.once.Do(func() {
+		// Any possible errors have already been checked in the Decode
+		// call to [UnescapeErrorChecker].
+		//nolint:errcheck,gosec
+		(&s.KeyValuePairs).Decode(s.input, s.separator)
+
+		s.input = ""
+		s.separator = ""
+	})
+}

--- a/internal/store.go
+++ b/internal/store.go
@@ -2,7 +2,7 @@ package internal
 
 import "sync"
 
-// KeyValueStore provides access to a multi-valued map.
+// KeyValueStore provides access to a multi-valued key/value map.
 type KeyValueStore interface {
 	// Get returns the first value for the given key. Empty string otherwise.
 	Get(key string) string
@@ -17,11 +17,11 @@ type KeyValueStore interface {
 	Len() int
 }
 
-// KeyValuePairs stores key to values similar to that of [url.Values]
+// KeyValuePairs stores key to values similar to that of [net/url.Values]
 // and implements [KeyValueStore].
 type KeyValuePairs map[string][]string
 
-// Decode populates the Store with the given data, returing any encoding errors
+// Decode populates the store with the given data, returing any encoding errors
 // encountered.
 func (m *KeyValuePairs) Decode(input, separator string) error {
 	var err error

--- a/internal/store_test.go
+++ b/internal/store_test.go
@@ -1,0 +1,105 @@
+package internal_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/percivalalb/sipuri/internal"
+)
+
+func TestKeyValueStore(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		input        internal.KeyValueStore
+		expectValues map[string][]string
+		expectKeys   []string
+		msg          string
+	}
+
+	tests := []test{
+		{
+			internal.KeyValuePairs{},
+			map[string][]string{
+				"unknown": nil,
+			},
+			nil,
+			"empty key/value pairs",
+		},
+		{
+			internal.KeyValuePairs{
+				"key1": {""},
+			},
+			map[string][]string{
+				"key1": {""},
+			},
+			[]string{"key1"},
+			"key/value pairs single key",
+		},
+		{
+			internal.KeyValuePairs{
+				"animals":   {"cat", "dog", "parrot"},
+				"health":    {"good", "good", "good"},
+				"locations": {"england"},
+			},
+			map[string][]string{
+				"animals":   {"cat", "dog", "parrot"},
+				"health":    {"good", "good", "good"},
+				"locations": {"england"},
+			},
+			[]string{"animals", "health", "locations"},
+			"many key/value pairs",
+		},
+		{
+			internal.EmptyStore{},
+			map[string][]string{
+				"unknown": nil,
+			},
+			nil,
+			"empty store",
+		},
+		{
+			createLazyStore(t, "key1=value1&key2=value2&key3=value2&key1=value1", "&"),
+			map[string][]string{
+				"key1":    {"value1", "value1"},
+				"key2":    {"value2"},
+				"key3":    {"value2"},
+				"unknown": nil,
+			},
+			[]string{"key1", "key2", "key3"},
+			"lazy store",
+		},
+	}
+
+	for _, test := range tests {
+		for k, v := range test.expectValues {
+			var firstV string
+			if len(v) > 0 {
+				firstV = v[0]
+			}
+
+			equalF(t, firstV, test.input.Get(k), "%s: first value mismatch", test.msg)
+			equalF(t, v, test.input.GetAll(k), "%s: values mismatch", test.msg)
+		}
+
+		// Sorts as keys are returned in an arbitrary order.
+		keys := test.input.Keys()
+		sort.Strings(keys)
+
+		equalF(t, test.expectKeys, keys, "%s: keys mismatch", test.msg)
+
+		equalF(t, len(test.expectKeys), test.input.Len(), "%s: len mismatch", test.msg)
+	}
+}
+
+func createLazyStore(t *testing.T, input, separator string) *internal.LazyStore {
+	t.Helper()
+
+	s := &internal.LazyStore{}
+
+	if err := s.Decode(input, separator); err != nil {
+		t.Fatalf("err %v", err)
+	}
+
+	return s
+}

--- a/parse.go
+++ b/parse.go
@@ -6,7 +6,7 @@ import (
 	"github.com/percivalalb/sipuri/internal"
 )
 
-// Parse parses the given uri.
+// Parse parses the given URI.
 func Parse(uri string) (*URI, error) {
 	if strings.HasPrefix(uri, SIPProtocol) {
 		return parse(SIP, uri[len(SIPProtocol):], false)
@@ -19,7 +19,10 @@ func Parse(uri string) (*URI, error) {
 	return nil, MalformedError{Cause: InvalidScheme}
 }
 
-// ParseLazy parses the given uri, lazily loading the uri parameters & headers.
+// ParseLazy parses the given URI, lazily decoding the URI params & headers.
+//
+// Prefer [Parse] over this function. This version is intended where latency
+// is paramount and params & headers are not inspected.
 func ParseLazy(uri string) (*URI, error) {
 	if strings.HasPrefix(uri, SIPProtocol) {
 		return parse(SIP, uri[len(SIPProtocol):], true)

--- a/parse.go
+++ b/parse.go
@@ -16,7 +16,7 @@ func Parse(uri string) (*URI, error) {
 		return parse(SIPS, uri[len(SIPSProtocol):], false)
 	}
 
-	return nil, ErrInvalidScheme
+	return nil, MalformedURIError{Cause: InvalidScheme}
 }
 
 // ParseLazy parses the given uri, lazily loading the uri parameters & headers.
@@ -29,7 +29,7 @@ func ParseLazy(uri string) (*URI, error) {
 		return parse(SIPS, uri[len(SIPSProtocol):], true)
 	}
 
-	return nil, ErrInvalidScheme
+	return nil, MalformedURIError{Cause: InvalidScheme}
 }
 
 //nolint:cyclop,funlen

--- a/parse.go
+++ b/parse.go
@@ -1,6 +1,10 @@
 package sipuri
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/percivalalb/sipuri/internal"
+)
 
 // Parse parses the given uri.
 func Parse(uri string) (*URI, error) {
@@ -63,7 +67,7 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 	// RFC requires : to be escaped in the userinfo. So split on :.
 	sipURI.user, sipURI.pass, sipURI.hadPass = strings.Cut(userinfo, ":")
 
-	user, err := Unescape(sipURI.user)
+	user, err := internal.Unescape(sipURI.user)
 	if err != nil {
 		return nil, MalformedURIError{Cause: MalformedUser, Err: err}
 	}
@@ -72,7 +76,7 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 
 	// Typically the host should not contain any escaped characters but
 	// it is possible in the spec.
-	host, err = Unescape(host)
+	host, err = internal.Unescape(host)
 	if err != nil {
 		return nil, MalformedURIError{Cause: MalformedHost, Err: err}
 	}
@@ -86,16 +90,16 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 
 	switch {
 	case params == "":
-		sipURI.params = EmptyStore{}
+		sipURI.params = internal.EmptyStore{}
 	case lazy:
-		var temp LazyStore
+		var temp internal.LazyStore
 		if err := (&temp).Decode(params, ";"); err != nil {
 			return nil, MalformedURIError{Cause: MalformedParams, Err: err}
 		}
 
 		sipURI.params = &temp
 	default:
-		var temp KeyValuePairs
+		var temp internal.KeyValuePairs
 		if err := (&temp).Decode(params, ";"); err != nil {
 			return nil, MalformedURIError{Cause: MalformedParams, Err: err}
 		}
@@ -105,16 +109,16 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 
 	switch {
 	case headers == "":
-		sipURI.headers = EmptyStore{}
+		sipURI.headers = internal.EmptyStore{}
 	case lazy:
-		var temp LazyStore
+		var temp internal.LazyStore
 		if err := (&temp).Decode(headers, "&"); err != nil {
 			return nil, MalformedURIError{Cause: MalformedHeaders, Err: err}
 		}
 
 		sipURI.headers = &temp
 	default:
-		var temp KeyValuePairs
+		var temp internal.KeyValuePairs
 		if err := (&temp).Decode(headers, "&"); err != nil {
 			return nil, MalformedURIError{Cause: MalformedHeaders, Err: err}
 		}

--- a/parse.go
+++ b/parse.go
@@ -16,7 +16,7 @@ func Parse(uri string) (*URI, error) {
 		return parse(SIPS, uri[len(SIPSProtocol):], false)
 	}
 
-	return nil, MalformedURIError{Cause: InvalidScheme}
+	return nil, MalformedError{Cause: InvalidScheme}
 }
 
 // ParseLazy parses the given uri, lazily loading the uri parameters & headers.
@@ -29,7 +29,7 @@ func ParseLazy(uri string) (*URI, error) {
 		return parse(SIPS, uri[len(SIPSProtocol):], true)
 	}
 
-	return nil, MalformedURIError{Cause: InvalidScheme}
+	return nil, MalformedError{Cause: InvalidScheme}
 }
 
 //nolint:cyclop,funlen
@@ -42,15 +42,25 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 	if hasAt {
 		// §19.1.1 "If the @ sign is present in a SIP or SIPS URI, the user field MUST NOT be empty."
 		if userinfo == "" {
-			return nil, MalformedURIError{Cause: MissingUser}
+			return nil, MalformedError{Cause: MissingUser}
 		}
 	} else {
 		userinfo, postfix = postfix, userinfo // swap (makes userinfo empty)
 	}
 
+	// RFC requires : to be escaped in the userinfo. So split on :.
+	sipURI.user, sipURI.pass, sipURI.hadPass = strings.Cut(userinfo, ":")
+
+	user, err := internal.Unescape(sipURI.user)
+	if err != nil {
+		return nil, MalformedError{Cause: MalformedUser, Err: err}
+	}
+
+	sipURI.user = user
+
 	// The uri must have been a single '@'
 	if postfix == "" {
-		return nil, MalformedURIError{Cause: MissingHost}
+		return nil, MalformedError{Cause: MissingHost}
 	}
 
 	prefix, headers, hadHeader := strings.Cut(postfix, "?")
@@ -58,34 +68,24 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 
 	// §19.1.2 host mandatory in all contexts
 	if host == "" {
-		return nil, MalformedURIError{Cause: MissingHost}
+		return nil, MalformedError{Cause: MissingHost}
 	}
 
 	sipURI.hadHeader = hadHeader
 	sipURI.hadParam = hadParam
 
-	// RFC requires : to be escaped in the userinfo. So split on :.
-	sipURI.user, sipURI.pass, sipURI.hadPass = strings.Cut(userinfo, ":")
-
-	user, err := internal.Unescape(sipURI.user)
-	if err != nil {
-		return nil, MalformedURIError{Cause: MalformedUser, Err: err}
-	}
-
-	sipURI.user = user
-
 	// Typically the host should not contain any escaped characters but
 	// it is possible in the spec.
 	host, err = internal.Unescape(host)
 	if err != nil {
-		return nil, MalformedURIError{Cause: MalformedHost, Err: err}
+		return nil, MalformedError{Cause: MalformedHost, Err: err}
 	}
 
 	sipURI.host = host
 
 	// Check the host port is not malformed
 	if _, _, err := sipURI.SplitHostPort(); err != nil {
-		return nil, MalformedURIError{Cause: MalformedHost, Err: err}
+		return nil, MalformedError{Cause: MalformedHost, Err: err}
 	}
 
 	switch {
@@ -94,14 +94,14 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 	case lazy:
 		var temp internal.LazyStore
 		if err := (&temp).Decode(params, ";"); err != nil {
-			return nil, MalformedURIError{Cause: MalformedParams, Err: err}
+			return nil, MalformedError{Cause: MalformedParams, Err: err}
 		}
 
 		sipURI.params = &temp
 	default:
 		var temp internal.KeyValuePairs
 		if err := (&temp).Decode(params, ";"); err != nil {
-			return nil, MalformedURIError{Cause: MalformedParams, Err: err}
+			return nil, MalformedError{Cause: MalformedParams, Err: err}
 		}
 
 		sipURI.params = temp
@@ -113,14 +113,14 @@ func parse(proto Protocol, uri string, lazy bool) (*URI, error) {
 	case lazy:
 		var temp internal.LazyStore
 		if err := (&temp).Decode(headers, "&"); err != nil {
-			return nil, MalformedURIError{Cause: MalformedHeaders, Err: err}
+			return nil, MalformedError{Cause: MalformedHeaders, Err: err}
 		}
 
 		sipURI.headers = &temp
 	default:
 		var temp internal.KeyValuePairs
 		if err := (&temp).Decode(headers, "&"); err != nil {
-			return nil, MalformedURIError{Cause: MalformedHeaders, Err: err}
+			return nil, MalformedError{Cause: MalformedHeaders, Err: err}
 		}
 
 		sipURI.headers = temp

--- a/parse_test.go
+++ b/parse_test.go
@@ -171,7 +171,7 @@ func TestParseError(t *testing.T) {
 	tests := []test{
 		{
 			"user@example.sip.twilio.com;transport=TCP",
-			sipuri.ErrInvalidScheme,
+			sipuri.MalformedURIError{Cause: sipuri.InvalidScheme},
 			"no scheme present",
 		},
 		{

--- a/parse_test.go
+++ b/parse_test.go
@@ -30,10 +30,10 @@ func TestParse(t *testing.T) {
 			"user",
 			"host:port",
 			sipuri.WithPassword("password"),
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"uri-parameters": {""},
 			}),
-			sipuri.WithHeaders(sipuri.KeyValuePairs{
+			sipuri.WithHeaders(sipuri.Headers{
 				"headers": {""},
 			}),
 		), "UDP", "template uri"},
@@ -47,7 +47,7 @@ func TestParse(t *testing.T) {
 			"alice",
 			"atlanta.com",
 			sipuri.WithPassword("secretword"),
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"transport": {"tcp"},
 			}),
 		), "TCP", "RFC example #1"},
@@ -55,7 +55,7 @@ func TestParse(t *testing.T) {
 			"alice",
 			"atlanta.com",
 			sipuri.Secure(),
-			sipuri.WithHeaders(sipuri.KeyValuePairs{
+			sipuri.WithHeaders(sipuri.Headers{
 				"subject":  {"project x"},
 				"priority": {"urgent"},
 			}),
@@ -64,7 +64,7 @@ func TestParse(t *testing.T) {
 			"+1-212-555-1212",
 			"gateway.com",
 			sipuri.WithPassword("1234"),
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"user": {"phone"},
 			}),
 		), "UDP", "RFC example #3"},
@@ -80,10 +80,10 @@ func TestParse(t *testing.T) {
 		{"sip:atlanta.com;method=REGISTER?to=alice%40atlanta.com", sipuri.New(
 			"",
 			"atlanta.com",
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"method": {"REGISTER"},
 			}),
-			sipuri.WithHeaders(sipuri.KeyValuePairs{
+			sipuri.WithHeaders(sipuri.Headers{
 				"to": {"alice@atlanta.com"},
 			}),
 		), "UDP", "RFC example #6"},
@@ -106,14 +106,14 @@ func TestParse(t *testing.T) {
 		{"sip:bob@nokia.com;transport=tcp", sipuri.New(
 			"bob",
 			"nokia.com",
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"transport": {"tcp"},
 			}),
 		), "TCP", "O'Reilly example #2"},
 		{"sip:+1-212-555-1234@gw.com;user=phone", sipuri.New(
 			"+1-212-555-1234",
 			"gw.com",
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"user": {"phone"},
 			}),
 		), "UDP", "O'Reilly example #3"},
@@ -124,7 +124,7 @@ func TestParse(t *testing.T) {
 		{"sip:bob.smith@registrar.com;method=REGISTER", sipuri.New(
 			"bob.smith",
 			"registrar.com",
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"method": {"REGISTER"},
 			}),
 		), "UDP", "O'Reilly example #5"},

--- a/parse_test.go
+++ b/parse_test.go
@@ -250,7 +250,7 @@ func ExampleParse() {
 		panic(err)
 	}
 
-	// Print the consistent components
+	// Print the constituent components:
 	fmt.Println(sipURI.User())
 	fmt.Println(sipURI.Password())
 	fmt.Println(sipURI.Host())
@@ -258,7 +258,7 @@ func ExampleParse() {
 	fmt.Printf("%q\n", sipURI.Headers().GetAll("headers"))
 	fmt.Printf("%q\n", sipURI.Headers().Keys())
 
-	// Re-construct the URI
+	// Re-construct the URI:
 	fmt.Println(sipURI.String())
 
 	// Output:

--- a/parse_test.go
+++ b/parse_test.go
@@ -171,62 +171,62 @@ func TestParseError(t *testing.T) {
 	tests := []test{
 		{
 			"user@example.sip.twilio.com;transport=TCP",
-			sipuri.MalformedURIError{Cause: sipuri.InvalidScheme},
+			sipuri.MalformedError{Cause: sipuri.InvalidScheme},
 			"no scheme present",
 		},
 		{
 			"sip:user@",
-			sipuri.MalformedURIError{Cause: sipuri.MissingHost},
+			sipuri.MalformedError{Cause: sipuri.MissingHost},
 			"no host present",
 		},
 		{
 			"sip:@",
-			sipuri.MalformedURIError{Cause: sipuri.MissingUser},
+			sipuri.MalformedError{Cause: sipuri.MissingUser},
 			"lonely at symbol",
 		},
 		{
 			"sip:@;",
-			sipuri.MalformedURIError{Cause: sipuri.MissingUser},
+			sipuri.MalformedError{Cause: sipuri.MissingUser},
 			"lonely at symbol",
 		},
 		{
 			"sip:user@;",
-			sipuri.MalformedURIError{Cause: sipuri.MissingHost},
+			sipuri.MalformedError{Cause: sipuri.MissingHost},
 			"lonely at symbol",
 		},
 		{
 			"sip:@example.sip.twilio.com",
-			sipuri.MalformedURIError{Cause: sipuri.MissingUser},
+			sipuri.MalformedError{Cause: sipuri.MissingUser},
 			"no user present",
 		},
 		{
 			"sip:%xx@example.sip.twilio.com",
-			sipuri.MalformedURIError{Cause: sipuri.MalformedUser},
+			sipuri.MalformedError{Cause: sipuri.MalformedUser},
 			"malformed url encoded users",
 		},
 		{
 			"sip:user@%xxexample.sip.twilio.com",
-			sipuri.MalformedURIError{Cause: sipuri.MalformedHost},
+			sipuri.MalformedError{Cause: sipuri.MalformedHost},
 			"malformed url encoded host",
 		},
 		{
 			"sip:%xxexample.sip.twilio.com",
-			sipuri.MalformedURIError{Cause: sipuri.MalformedHost},
+			sipuri.MalformedError{Cause: sipuri.MalformedHost},
 			"malformed url encoded host",
 		},
 		{
 			"sip:user@example.sip.twilio.com;%xx",
-			sipuri.MalformedURIError{Cause: sipuri.MalformedParams},
+			sipuri.MalformedError{Cause: sipuri.MalformedParams},
 			"malformed url encoded params",
 		},
 		{
 			"sip:user@example.sip.twilio.com?%xx",
-			sipuri.MalformedURIError{Cause: sipuri.MalformedHeaders},
+			sipuri.MalformedError{Cause: sipuri.MalformedHeaders},
 			"malformed url encoded headers",
 		},
 		{
 			"sip:[::1",
-			sipuri.MalformedURIError{Cause: sipuri.MalformedHost},
+			sipuri.MalformedError{Cause: sipuri.MalformedHost},
 			"malformed ipv6 host",
 		},
 	}

--- a/sipuri.go
+++ b/sipuri.go
@@ -10,6 +10,8 @@ package sipuri
 import (
 	"net"
 	"strings"
+
+	"github.com/percivalalb/sipuri/internal"
 )
 
 // The two sip protocols.
@@ -34,59 +36,12 @@ type URI struct {
 	user    string
 	pass    string
 	host    string
-	params  KeyValueStore
-	headers KeyValueStore
+	params  internal.KeyValueStore
+	headers internal.KeyValueStore
 
 	hadPass   bool
 	hadParam  bool
 	hadHeader bool
-}
-
-type uriOption func(u *URI)
-
-// WithParams allows URI params to be set.
-func WithParams(params KeyValueStore) uriOption {
-	return func(u *URI) {
-		u.params = params
-	}
-}
-
-// WithHeaders allows URI headers to be set.
-func WithHeaders(headers KeyValueStore) uriOption {
-	return func(u *URI) {
-		u.headers = headers
-	}
-}
-
-// WithPassword allows the password portion of the user-info to be set.
-//
-// Use of a password is not advised and is inherently insecure. Use other
-// methods to ensure communication.
-func WithPassword(pass string) uriOption {
-	return func(u *URI) {
-		u.pass = pass
-	}
-}
-
-// Secure upgrades the URI to the SIPS protocol.
-func Secure() uriOption {
-	return func(u *URI) {
-		u.proto = SIPS
-	}
-}
-
-// New constructs a SIP URI with the given options.
-func New(user, host string, opts ...uriOption) URI {
-	u := URI{
-		user: user,
-		host: host,
-	}
-
-	for _, opt := range opts {
-		opt(&u)
-	}
-
-	return u
 }
 
 // Transport returns the Transport protocols that would be used to make a
@@ -150,20 +105,20 @@ func (sipURI URI) String() string {
 	}
 
 	if sipURI.user != "" {
-		builder.WriteString(escape(sipURI.user, encodeUserPassword))
+		builder.WriteString(internal.Escape(sipURI.user, internal.EncodeUserPassword))
 
 		if sipURI.hadPass || sipURI.pass != "" {
 			builder.WriteRune(':')
 		}
 
 		if sipURI.pass != "" {
-			builder.WriteString(escape(sipURI.pass, encodeUserPassword))
+			builder.WriteString(internal.Escape(sipURI.pass, internal.EncodeUserPassword))
 		}
 
 		builder.WriteByte('@') // only present when user is non-empty
 	}
 
-	builder.WriteString(escape(sipURI.host, encodeHost))
+	builder.WriteString(internal.Escape(sipURI.host, internal.EncodeHost))
 
 	if sipURI.hadParam || !sipURI.Params().Empty() {
 		builder.WriteByte(';')
@@ -224,18 +179,18 @@ func (sipURI URI) SplitHostPort() (string, string, error) {
 }
 
 // Params returns the decoded params portion of the URI.
-func (sipURI URI) Params() KeyValueStore {
+func (sipURI URI) Params() internal.KeyValueStore {
 	if sipURI.params == nil {
-		return EmptyStore{}
+		return internal.EmptyStore{}
 	}
 
 	return sipURI.params
 }
 
 // Headers returns the decoded headers portion of the URI.
-func (sipURI URI) Headers() KeyValueStore {
+func (sipURI URI) Headers() internal.KeyValueStore {
 	if sipURI.headers == nil {
-		return EmptyStore{}
+		return internal.EmptyStore{}
 	}
 
 	return sipURI.headers

--- a/sipuri.go
+++ b/sipuri.go
@@ -120,19 +120,19 @@ func (sipURI URI) String() string {
 
 	builder.WriteString(internal.Escape(sipURI.host, internal.EncodeHost))
 
-	if sipURI.hadParam || !sipURI.Params().Empty() {
+	if sipURI.hadParam || sipURI.Params().Len() > 0 {
 		builder.WriteByte(';')
 	}
 
-	if !sipURI.Params().Empty() {
+	if sipURI.Params().Len() > 0 {
 		builder.WriteString(sipURI.Params().Encode())
 	}
 
-	if sipURI.hadHeader || !sipURI.Headers().Empty() {
+	if sipURI.hadHeader || sipURI.Headers().Len() > 0 {
 		builder.WriteByte('?')
 	}
 
-	if !sipURI.Headers().Empty() {
+	if sipURI.Headers().Len() > 0 {
 		builder.WriteString(sipURI.Headers().Encode())
 	}
 

--- a/sipuri.go
+++ b/sipuri.go
@@ -4,7 +4,7 @@
 //
 //	sip:user:password@host:port;uri-parameters?headers
 //
-// From https://www.rfc-editor.org/rfc/rfc3261#section-19
+// and follows the spec from https://www.rfc-editor.org/rfc/rfc3261#section-19
 package sipuri
 
 import (
@@ -44,8 +44,11 @@ type URI struct {
 	hadHeader bool
 }
 
-// Transport returns the Transport protocols that would be used to make a
+// Transport returns the Transport protocol that would be used to make a
 // connection to the host.
+//
+// The transport URI param takes priority otherwise falling back to the defaults
+// for the scheme.
 func (sipURI URI) Transport() string {
 	if transport := sipURI.Params().Get("transport"); transport != "" {
 		return strings.ToUpper(transport)
@@ -62,10 +65,25 @@ func (sipURI URI) Transport() string {
 	}
 }
 
-// Port returns the port split from the host portion returning the
-// defaults based on transport protocol & scheme if not present.
+// SplitHostPort splits the port from the host portion.
 //
-// Returns an empty string in the case of the sip proto & unexpected transport.
+// An empty string for the port (and no error) is returned if no port is
+// explicitly set.
+func (sipURI URI) SplitHostPort() (string, string, error) {
+	ipv6 := len(sipURI.host) > 0 && sipURI.host[0] == '['
+	colonCount := strings.Count(sipURI.host, ":")
+
+	if (!ipv6 && colonCount > 0) || (ipv6 && (colonCount%2 == 1 || sipURI.host[len(sipURI.host)-1] != ']')) {
+		return net.SplitHostPort(sipURI.host) //nolint:wrapcheck
+	}
+
+	return sipURI.host, "", nil
+}
+
+// Port returns the port explicitly set in the host portion, if not present
+// it returns the default based on scheme & transport protocol.
+//
+// Returns an empty string if the sip scheme has an unknown transport.
 func (sipURI URI) Port() string {
 	_, port, _ := sipURI.SplitHostPort()
 
@@ -91,7 +109,7 @@ func (sipURI URI) Port() string {
 	return ""
 }
 
-// String rebuilds the string representation of the URI respecting the quirks of the input.
+// String builds the string representation of the URI.
 //
 //nolint:cyclop
 func (sipURI URI) String() string {
@@ -139,8 +157,8 @@ func (sipURI URI) String() string {
 	return builder.String()
 }
 
-// Secure returns if the URI has been upgrade to the SIPS scheme.
-func (sipURI URI) Secure() Protocol {
+// Secure returns if the URI has been upgraded to the SIPS scheme.
+func (sipURI URI) Secure() bool {
 	return sipURI.proto == SIPS
 }
 
@@ -161,24 +179,14 @@ func (sipURI URI) Password() string {
 
 // Host returns the decoded host portion of the URI.
 //
-// You may want to use SplitHostPort.
+// You may want to use [URI.SplitHostPort] & [URI.Port].
 func (sipURI URI) Host() string {
 	return sipURI.host
 }
 
-// SplitHostPort splits the port from the host portion into.
-func (sipURI URI) SplitHostPort() (string, string, error) {
-	ipv6 := len(sipURI.host) > 0 && sipURI.host[0] == '['
-	colonCount := strings.Count(sipURI.host, ":")
-
-	if (!ipv6 && colonCount > 0) || (ipv6 && (colonCount%2 == 1 || sipURI.host[len(sipURI.host)-1] != ']')) {
-		return net.SplitHostPort(sipURI.host) //nolint:wrapcheck
-	}
-
-	return sipURI.host, "", nil
-}
-
-// Params returns the decoded params portion of the URI.
+// Params returns the decoded params portion of the URI. There may be none.
+//
+// The params are the key/values pairs after `;` but before `?`.
 func (sipURI URI) Params() internal.KeyValueStore {
 	if sipURI.params == nil {
 		return internal.EmptyStore{}
@@ -187,7 +195,9 @@ func (sipURI URI) Params() internal.KeyValueStore {
 	return sipURI.params
 }
 
-// Headers returns the decoded headers portion of the URI.
+// Headers returns the decoded headers portion of the URI. There may be none.
+//
+// The headers are the key/values pairs after `?`.
 func (sipURI URI) Headers() internal.KeyValueStore {
 	if sipURI.headers == nil {
 		return internal.EmptyStore{}

--- a/sipuri_test.go
+++ b/sipuri_test.go
@@ -21,17 +21,17 @@ func TestNew(t *testing.T) {
 			"user",
 			"host:port",
 			sipuri.WithPassword("password"),
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"uri-parameters": {""},
 			}),
-			sipuri.WithHeaders(sipuri.KeyValuePairs{
+			sipuri.WithHeaders(sipuri.Headers{
 				"headers": {""},
 			}),
 		), "template uri"},
 		{"sips:user@host", sipuri.New("user", "host", sipuri.Secure()), "secure upgrade"},
 		{"sip:user@host;key1=value1&key2=value2&key2=value3", sipuri.New(
 			"user", "host",
-			sipuri.WithParams(sipuri.KeyValuePairs{
+			sipuri.WithParams(sipuri.Params{
 				"key1": {"value1"},
 				"key2": {"value2", "value3"},
 				"key3": nil,
@@ -47,10 +47,10 @@ func TestNew(t *testing.T) {
 		"user",
 		"host:port",
 		sipuri.WithPassword("password"),
-		sipuri.WithParams(sipuri.KeyValuePairs{
+		sipuri.WithParams(sipuri.Params{
 			"uri-parameters": {""},
 		}),
-		sipuri.WithHeaders(sipuri.KeyValuePairs{
+		sipuri.WithHeaders(sipuri.Headers{
 			"headers": {""},
 		}),
 	)
@@ -75,10 +75,10 @@ func ExampleNew() {
 		"user",
 		"host:port",
 		sipuri.WithPassword("password"),
-		sipuri.WithParams(sipuri.KeyValuePairs{
+		sipuri.WithParams(sipuri.Params{
 			"uri-parameters": {""},
 		}),
-		sipuri.WithHeaders(sipuri.KeyValuePairs{
+		sipuri.WithHeaders(sipuri.Headers{
 			"headers": {""},
 		}),
 	)


### PR DESCRIPTION
v2 re-structures the layout of the project to reduce & clean up the public API footprint:
  - Moves code to an `internal/` folder (which is effectively private in Golang). This hides:
    - Functions `EncodeURLValues`, `UnescapeErrorChecker` & `Unescape`.
    - Types `EmptyStore`, `KeyValuePairs` & `LazyStore`.
  - Renamed `MalformedURIError` so it reads better when used with the package name `sipuri.MalformedError`.
  - Removed variable `ErrInvalidScheme` replaced with a `MalformCause`, so effectively changing:
```golang
sipuri.MalformedError{Cause: sipuri.InvalidScheme} // replaces sipuri.ErrInvalidScheme
```
- Moved the `MalformedUser` check to before the `MissingHost` check so that the checks are all done in the order of the components in URI
- Added `sipuri.Params` & `sipuri.Headers` types alias to use with the builder options which reads nicer than `KeyValuePairs`.
- Remove the `.Emtpy()` method from the `KeyValueStore` type. The equivelant can be determined with the `.Len()` method.
- Updated the documentation to be fuller and clearer