### PR TITLE
Add fuzz tests & fix panics 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ jobs:
           command: |
             gotestsum --junitfile report.xml --format testname -- -coverprofile=coverage.txt -race -v ./...
             go tool cover -html=coverage.txt -o coverage.html
+      - run:
+          name: Run fuzz
+          command: |
+             go test -fuzz=FuzzNew --fuzztime=10s -parallel=3
+             go test -fuzz=FuzzParse --fuzztime=10s -parallel=3
       - store_test_results:
           path: report.xml
       - store_artifacts:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,6 +38,10 @@ linters:
       - linters:
           - ireturn
         path: sipuri\.go
+      - linters:
+          - cyclop
+          - gocognit
+        text: 'func(tion)? `?Fuzz'
     paths:
       - third_party$
       - builtin$

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,111 @@
+//nolint:testpackage // Needs access to private type uriOption
+package sipuri
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func FuzzNew(f *testing.F) {
+	f.Add(false, "user", "", "example.com", "", "")
+	f.Add(true, "name", "password123", "sipserver.com", `{"key":["value"]}`, "")
+	f.Add(false, "", "", "sipserver.com:1234", "", `{"key":["value"]}`)
+
+	f.Fuzz(func(t *testing.T, secure bool, user, password, host, headersJSON, parametersJSON string) {
+		func() {
+			uriStr := "<not-computed>"
+
+			// Catch any unexpected (or expected in places below) panics and report failure.
+			defer func() {
+				err := recover()
+				if err != nil {
+					t.Errorf("panic building SIP URL %q %s", uriStr, err)
+				}
+			}()
+
+			var headers map[string][]string
+			if err := json.Unmarshal([]byte(headersJSON), &headers); headersJSON != "" && err != nil {
+				t.Skip()
+			}
+
+			var parameters map[string][]string
+			if err := json.Unmarshal([]byte(parametersJSON), &parameters); parametersJSON != "" && err != nil {
+				t.Skip()
+			}
+
+			var opts []uriOption
+
+			if secure {
+				opts = append(opts, Secure())
+			}
+
+			if password != "" {
+				opts = append(opts, WithPassword(password))
+			}
+
+			if headers != nil {
+				opts = append(opts, WithHeaders(headers))
+			}
+
+			if parameters != nil {
+				opts = append(opts, WithParams(parameters))
+			}
+
+			uri := New(user, host, opts...)
+
+			// This is the main part we are checking does not panic.
+			uriStr = uri.String()
+
+			// Check other methods return sensible values and also do not panic.
+
+			if atCount := strings.Count(uriStr, "@"); atCount > 1 {
+				panic(fmt.Sprintf("at symbol count not 0 or 1 (actual: %d)", atCount))
+			}
+
+			if colonCount := strings.Count(uriStr, ":"); colonCount == 0 {
+				panic(fmt.Sprintf("colon symbol (actual: %d)", colonCount))
+			}
+
+			port := uri.Port()
+			if port == "" {
+				panic("empty port SIP URL")
+			}
+
+			transport := uri.Transport()
+			if transport == "" {
+				panic("empty transport protocol")
+			}
+		}()
+	})
+}
+
+func FuzzParse(f *testing.F) {
+	f.Add(false, "sip:user:password@host:port;uri-parameters?headers")
+	f.Add(true, "sip:user@example.invalid")
+
+	f.Fuzz(func(t *testing.T, lazy bool, input string) {
+		func() {
+			// Catch any unexpected (or expected in places below) panics and report failure.
+			defer func() {
+				err := recover()
+				if err != nil {
+					t.Errorf("panic parsing SIP URL %s, %s", input, err)
+				}
+			}()
+
+			parseFunc := Parse
+			if lazy {
+				parseFunc = ParseLazy
+			}
+
+			// This is the main part we are checking does not panic.
+			uri, err := parseFunc(input)
+
+			if uri == nil && err == nil {
+				panic("nil SIP uri struct")
+			}
+		}()
+	})
+}

--- a/internal/escape.go
+++ b/internal/escape.go
@@ -259,28 +259,35 @@ func Unescape(input string) (string, error) {
 // It is a stripped down version of [Unescape] without actually extracting the parts
 // or decoding the string it returns an error if and only if the aforementioned does.
 func UnescapeErrorChecker(input string) error {
-	l := len(input)
+	length := len(input)
 
-	switch {
-	case l == 0:
-		return nil
-	case input[l-1] == '%':
-		return URIEscapeError("%")
-	case input[l-2] == '%':
-		return URIEscapeError(input[l-2:])
-	}
+	for pos := 0; pos < length; pos++ {
+		if input[pos] != '%' {
+			continue
+		}
 
-	for pos := 0; pos < l; pos++ {
-		if input[pos] == '%' {
-			gByte := checkValidHexCharacter(input[pos+1])
-			lByte := checkValidHexCharacter(input[pos+2])
+		// Default to error. Only if there is 2 more valid hex characters
+		// can this be avoided.
+		gByte, lByte := hexCharErrorBit, hexCharErrorBit
 
-			if (gByte|lByte)&hexCharErrorBit != 0 {
-				return URIEscapeError(input[pos : pos+3])
+		if pos+1 < length {
+			gByte = checkValidHexCharacter(input[pos+1])
+		}
+
+		if pos+2 < length {
+			lByte = checkValidHexCharacter(input[pos+2])
+		}
+
+		if (gByte|lByte)&hexCharErrorBit != 0 {
+			end := pos + 3 //nolint:mnd // can use min(pos+3, l) when targeting 1.21+
+			if end > length {
+				end = length
 			}
 
-			pos += 2
+			return URIEscapeError(input[pos:end])
 		}
+
+		pos += 2
 	}
 
 	return nil

--- a/internal/escape.go
+++ b/internal/escape.go
@@ -86,7 +86,7 @@ func Escape(input string, mode encoding) string {
 	required := len(input) + 2*hexCount //nolint:mnd
 	result := make([]byte, required)
 
-	escapeInto(input, 0, result)
+	mode.escapeInto(input, 0, result)
 
 	return string(result)
 }
@@ -188,9 +188,9 @@ func EncodeURLValues(input map[string][]string) string {
 				pos++
 			}
 
-			pos = escapeInto(key, pos, result)
+			pos = EncodeQueryComponent.escapeInto(key, pos, result)
 			result[pos] = '='
-			pos = escapeInto(val, pos+1, result)
+			pos = EncodeQueryComponent.escapeInto(val, pos+1, result)
 		}
 	}
 
@@ -201,10 +201,10 @@ const upperhex = "0123456789ABCDEF"
 
 // escapeInto escapes all of "input", writing the "result" into target
 // starting at index "offset".
-func escapeInto(input string, offset int, target []byte) int {
+func (mode encoding) escapeInto(input string, offset int, target []byte) int {
 	for pos := 0; pos < len(input); pos++ {
 		switch c := input[pos]; {
-		case EncodeQueryComponent.shouldEscape(c):
+		case mode.shouldEscape(c):
 			target[offset] = '%'
 			target[offset+1] = upperhex[c>>4]
 			target[offset+2] = upperhex[c&15]


### PR DESCRIPTION
Fixes #22 

The PR adds fuzz tests, namely `FuzzNew` & `FuzzParse`. Prompted by the self-discovery of a panic in the URI builder. Adding the fuzz tests for `ParseLazy` lead to the discovery of another panic and incorrect unescape error checking logc.